### PR TITLE
Update question form to include editable correct answer

### DIFF
--- a/admin/crud.php
+++ b/admin/crud.php
@@ -31,9 +31,10 @@ function editQuestion($conn)
 }
 function updateQuestion($conn)
 {
-    $sql  = 'UPDATE question SET question = :question WHERE id = :id';
+    $sql  = 'UPDATE question SET question = :question, correct_answer = :correct_answer WHERE id = :id';
     $stmt = $conn->prepare($sql);
     $stmt->bindParam(':question', $_POST['question']);
+    $stmt->bindParam(':correct_answer', $_POST['correct_answer']);
     $stmt->bindParam(':id', $_POST['id']);
     $stmt->execute();
 }

--- a/admin/views/edit-question.php
+++ b/admin/views/edit-question.php
@@ -1,7 +1,12 @@
 <form hx-post="crud.php?action=update">
+    <label class="form-label">Question</label>
     <div class="input-group input-group-sm">
         <input type="hidden" name="id" value="<?= $question['id'] ?>">
+        <!-- this edit the question -->
         <textarea rows="4" class="form-control" name="question"><?= $question['question'] ?></textarea>
     </div>
+    <label class="form-label mt-2">Correct Answer</label><br>
+    <!-- this edit the correct letter/answer -->
+    <input type="text" class="form-control text-uppercase" name="correct_answer" value="<?= $question['correct_answer'] ?>">
     <button class="btn btn-sm btn-dark mt-2" data-bs-dismiss="modal">Okay</button>
 </form>


### PR DESCRIPTION
Enhance the question editing functionality by adding an input field for the correct answer, allowing users to update both the question and its correct answer in a single form submission.